### PR TITLE
Security hardening: command injection, debug endpoints, credential leakage

### DIFF
--- a/src/routes/debug.ts
+++ b/src/routes/debug.ts
@@ -123,35 +123,13 @@ debug.get('/gateway-api', async (c) => {
   }
 });
 
-// GET /debug/cli - Test moltbot CLI commands (CLI is still named clawdbot)
+// GET /debug/cli - REMOVED: Arbitrary command execution is a security risk.
+// See: https://github.com/craig-ais/openclawai-sandbox2/issues/2
 debug.get('/cli', async (c) => {
-  const sandbox = c.get('sandbox');
-  const cmd = c.req.query('cmd') || 'clawdbot --help';
-  
-  try {
-    const proc = await sandbox.startProcess(cmd);
-    
-    // Wait longer for command to complete
-    let attempts = 0;
-    while (attempts < 30) {
-      await new Promise(r => setTimeout(r, 500));
-      if (proc.status !== 'running') break;
-      attempts++;
-    }
-
-    const logs = await proc.getLogs();
-    return c.json({
-      command: cmd,
-      status: proc.status,
-      exitCode: proc.exitCode,
-      attempts,
-      stdout: logs.stdout || '',
-      stderr: logs.stderr || '',
-    });
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return c.json({ error: errorMessage, command: cmd }, 500);
-  }
+  return c.json({
+    error: 'This endpoint has been removed for security reasons.',
+    hint: 'Use /debug/version or /debug/processes for diagnostics.',
+  }, 410);
 });
 
 // GET /debug/logs - Returns container logs for debugging
@@ -348,47 +326,18 @@ debug.get('/env', async (c) => {
     dev_mode: c.env.DEV_MODE,
     debug_routes: c.env.DEBUG_ROUTES,
     bind_mode: c.env.CLAWDBOT_BIND_MODE,
-    cf_access_team_domain: c.env.CF_ACCESS_TEAM_DOMAIN,
+    has_cf_access_team_domain: !!c.env.CF_ACCESS_TEAM_DOMAIN,
     has_cf_access_aud: !!c.env.CF_ACCESS_AUD,
   });
 });
 
-// GET /debug/container-config - Read the moltbot config from inside the container
+// GET /debug/container-config - REMOVED: Exposes raw credentials (API keys, bot tokens).
+// See: https://github.com/craig-ais/openclawai-sandbox2/issues/8
 debug.get('/container-config', async (c) => {
-  const sandbox = c.get('sandbox');
-  
-  try {
-    const proc = await sandbox.startProcess('cat /root/.clawdbot/clawdbot.json');
-    
-    let attempts = 0;
-    while (attempts < 10) {
-      await new Promise(r => setTimeout(r, 200));
-      if (proc.status !== 'running') break;
-      attempts++;
-    }
-
-    const logs = await proc.getLogs();
-    const stdout = logs.stdout || '';
-    const stderr = logs.stderr || '';
-    
-    let config = null;
-    try {
-      config = JSON.parse(stdout);
-    } catch {
-      // Not valid JSON
-    }
-    
-    return c.json({
-      status: proc.status,
-      exitCode: proc.exitCode,
-      config,
-      raw: config ? undefined : stdout,
-      stderr,
-    });
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return c.json({ error: errorMessage }, 500);
-  }
+  return c.json({
+    error: 'This endpoint has been removed for security reasons.',
+    hint: 'Use /debug/env for a sanitized view of configuration status.',
+  }, 410);
 });
 
 export { debug };

--- a/start-moltbot.sh
+++ b/start-moltbot.sh
@@ -282,7 +282,7 @@ if (isOpenAI) {
 // Write updated config
 fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 console.log('Configuration updated successfully');
-console.log('Config:', JSON.stringify(config, null, 2));
+// Note: Do NOT log the full config — it contains API keys and bot tokens (see issue #6)
 EOFNODE
 
 # ============================================================


### PR DESCRIPTION
## Summary
- **Fix critical command injection** in device approval endpoint (`requestId` now validated against `^[a-zA-Z0-9_-]+$`)
- **Remove `/debug/cli` endpoint** that allowed arbitrary command execution in the container
- **Remove `/debug/container-config`** that returned raw `clawdbot.json` containing all API keys and bot tokens
- **Remove config dump from startup script** (`console.log('Config:', ...)` line that logged all credentials to process stdout)
- **Stop leaking env var names** in config error JSON responses — now returns count only, details in server logs
- **WebSocket message logging** now logs metadata (type, size) only, never message content (which contains user prompts and AI responses)
- **Redact CF Access team domain** from `/debug/env` — now returns boolean presence check only

## Issues Closed
Closes #1, closes #2, closes #6, closes #8, closes #11, closes #14

## Test plan
- [ ] Verify `/api/admin/devices/:requestId/approve` rejects requestIds with special characters (`;`, `|`, `&`, spaces)
- [ ] Verify `/debug/cli` returns 410 Gone
- [ ] Verify `/debug/container-config` returns 410 Gone
- [ ] Verify config error response no longer lists specific variable names
- [ ] Verify WebSocket proxy still works correctly (messages relay without content logging)
- [ ] Verify startup script runs without the config dump line

🤖 Generated with [Claude Code](https://claude.com/claude-code)