### PR TITLE
Exclude credentials from R2 backup sync

### DIFF
--- a/src/gateway/sync.ts
+++ b/src/gateway/sync.ts
@@ -59,7 +59,10 @@ export async function syncToR2(sandbox: Sandbox, env: MoltbotEnv): Promise<SyncR
 
   // Run rsync to backup config to R2
   // Note: Use --no-times because s3fs doesn't support setting timestamps
-  const syncCmd = `rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' /root/.clawdbot/ ${R2_MOUNT_PATH}/clawdbot/ && rsync -r --no-times --delete /root/clawd/skills/ ${R2_MOUNT_PATH}/skills/ && date -Iseconds > ${R2_MOUNT_PATH}/.last-sync`;
+  // SECURITY: Exclude clawdbot.json from backup - it contains embedded API keys
+  // and secrets injected by start-moltbot.sh. The config is regenerated from
+  // environment variables on every container start, so it doesn't need persistence.
+  const syncCmd = `rsync -r --no-times --delete --exclude='*.lock' --exclude='*.log' --exclude='*.tmp' --exclude='clawdbot.json' /root/.clawdbot/ ${R2_MOUNT_PATH}/clawdbot/ && rsync -r --no-times --delete /root/clawd/skills/ ${R2_MOUNT_PATH}/skills/ && date -Iseconds > ${R2_MOUNT_PATH}/.last-sync`;
   
   try {
     const proc = await sandbox.startProcess(syncCmd);


### PR DESCRIPTION
## Summary
- **Excludes `clawdbot.json` from R2 rsync** — this file contains embedded API keys and secrets injected by `start-moltbot.sh` during container startup. The config is regenerated from environment variables on every boot, so it doesn't need persistence.
- **Cleans up legacy credential files from R2** — on restore, any existing `clawdbot.json` in the R2 backup is deleted to prevent future credential exposure from pre-patch backups.
- **Adds warning logs** when credential files are found in R2 backups during restore, alerting operators to the issue.

Closes #9

## Files Changed
| File | Change |
|------|--------|
| `src/gateway/sync.ts` | Added `--exclude='clawdbot.json'` to rsync command |
| `start-moltbot.sh` | Clean up credential files from R2 on restore; add warnings; change restore check to directory existence |

## Test plan
- [ ] Deploy to staging and verify R2 sync runs without `clawdbot.json` in backup
- [ ] Verify container restarts successfully (config regenerated from env vars)
- [ ] Manually place a `clawdbot.json` in R2 backup and confirm it gets cleaned up on next restore
- [ ] Verify skills and other non-credential config files still sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)