### PR TITLE
Bump openclaw to v2026.2.12 with CLI migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,25 +20,26 @@ RUN ARCH="$(dpkg --print-architecture)" \
 # Install pnpm globally
 RUN npm install -g pnpm
 
-# Install moltbot (CLI is still named clawdbot until upstream renames)
+# Install OpenClaw (formerly clawdbot/moltbot)
 # Pin to specific version for reproducible builds
-RUN npm install -g clawdbot@2026.1.24-3 \
-    && clawdbot --version
+RUN npm install -g openclaw@2026.2.12 \
+    && openclaw --version
 
-# Create moltbot directories (paths still use clawdbot until upstream renames)
-# Templates are stored in /root/.clawdbot-templates for initialization
-RUN mkdir -p /root/.clawdbot \
-    && mkdir -p /root/.clawdbot-templates \
+# Create OpenClaw directories
+# The openclaw package auto-creates ~/.clawdbot -> ~/.openclaw symlink for backward compat
+# Templates are stored separately for initialization
+RUN mkdir -p /root/.openclaw \
+    && mkdir -p /root/.openclaw-templates \
     && mkdir -p /root/clawd \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-01-28-v26-browser-skill
+# Build cache bust: 2026-02-13-v27-openclaw-rename
 COPY start-moltbot.sh /usr/local/bin/start-moltbot.sh
 RUN chmod +x /usr/local/bin/start-moltbot.sh
 
 # Copy default configuration template
-COPY moltbot.json.template /root/.clawdbot-templates/moltbot.json.template
+COPY moltbot.json.template /root/.openclaw-templates/moltbot.json.template
 
 # Copy custom skills
 COPY skills/ /root/clawd/skills/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "moltbot-sandbox",
+  "name": "openclawai-sandbox2",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "moltbot-sandbox",
+      "name": "openclawai-sandbox2",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.0.5",
         "hono": "^4.11.6",

--- a/skills/cloudflare-browser/SKILL.md
+++ b/skills/cloudflare-browser/SKILL.md
@@ -10,7 +10,7 @@ Control headless browsers via Cloudflare's Browser Rendering service using CDP (
 ## Prerequisites
 
 - `CDP_SECRET` environment variable set
-- Browser profile configured in clawdbot.json with `cdpUrl` pointing to the worker endpoint:
+- Browser profile configured in openclaw.json with `cdpUrl` pointing to the worker endpoint:
   ```json
   "browser": {
     "profiles": {

--- a/src/gateway/process.test.ts
+++ b/src/gateway/process.test.ts
@@ -7,7 +7,7 @@ import { createMockSandbox } from '../test-utils';
 function createFullMockProcess(overrides: Partial<Process> = {}): Process {
   return {
     id: 'test-id',
-    command: 'clawdbot gateway',
+    command: 'openclaw gateway',
     status: 'running',
     startTime: new Date(),
     endTime: undefined,
@@ -28,8 +28,8 @@ describe('findExistingMoltbotProcess', () => {
 
   it('returns null when only CLI commands are running', async () => {
     const processes = [
-      createFullMockProcess({ command: 'clawdbot devices list --json', status: 'running' }),
-      createFullMockProcess({ command: 'clawdbot --version', status: 'completed' }),
+      createFullMockProcess({ command: 'openclaw devices list --json', status: 'running' }),
+      createFullMockProcess({ command: 'openclaw --version', status: 'completed' }),
     ];
     const { sandbox, listProcessesMock } = createMockSandbox();
     listProcessesMock.mockResolvedValue(processes);
@@ -39,13 +39,13 @@ describe('findExistingMoltbotProcess', () => {
   });
 
   it('returns gateway process when running', async () => {
-    const gatewayProcess = createFullMockProcess({ 
+    const gatewayProcess = createFullMockProcess({
       id: 'gateway-1',
-      command: 'clawdbot gateway --port 18789', 
-      status: 'running' 
+      command: 'openclaw gateway --port 18789',
+      status: 'running'
     });
     const processes = [
-      createFullMockProcess({ command: 'clawdbot devices list', status: 'completed' }),
+      createFullMockProcess({ command: 'openclaw devices list', status: 'completed' }),
       gatewayProcess,
     ];
     const { sandbox, listProcessesMock } = createMockSandbox();
@@ -70,7 +70,7 @@ describe('findExistingMoltbotProcess', () => {
 
   it('ignores completed gateway processes', async () => {
     const processes = [
-      createFullMockProcess({ command: 'clawdbot gateway', status: 'completed' }),
+      createFullMockProcess({ command: 'openclaw gateway', status: 'completed' }),
       createFullMockProcess({ command: 'start-moltbot.sh', status: 'failed' }),
     ];
     const { sandbox, listProcessesMock } = createMockSandbox();
@@ -103,10 +103,10 @@ describe('findExistingMoltbotProcess', () => {
   });
 
   it('returns first matching gateway process', async () => {
-    const firstGateway = createFullMockProcess({ 
+    const firstGateway = createFullMockProcess({
       id: 'gateway-1',
-      command: 'clawdbot gateway', 
-      status: 'running' 
+      command: 'openclaw gateway',
+      status: 'running'
     });
     const secondGateway = createFullMockProcess({ 
       id: 'gateway-2',

--- a/src/gateway/process.ts
+++ b/src/gateway/process.ts
@@ -14,13 +14,15 @@ export async function findExistingMoltbotProcess(sandbox: Sandbox): Promise<Proc
   try {
     const processes = await sandbox.listProcesses();
     for (const proc of processes) {
-      // Only match the gateway process, not CLI commands like "clawdbot devices list"
-      // Note: CLI is still named "clawdbot" until upstream renames it
-      const isGatewayProcess = 
+      // Only match the gateway process, not CLI commands like "openclaw devices list"
+      const isGatewayProcess =
         proc.command.includes('start-moltbot.sh') ||
-        proc.command.includes('clawdbot gateway');
-      const isCliCommand = 
-        proc.command.includes('clawdbot devices') ||
+        proc.command.includes('openclaw gateway') ||
+        proc.command.includes('clawdbot gateway'); // legacy compat
+      const isCliCommand =
+        proc.command.includes('openclaw devices') ||
+        proc.command.includes('openclaw --version') ||
+        proc.command.includes('clawdbot devices') || // legacy compat
         proc.command.includes('clawdbot --version');
       
       if (isGatewayProcess && !isCliCommand) {

--- a/src/gateway/sync.test.ts
+++ b/src/gateway/sync.test.ts
@@ -39,19 +39,18 @@ describe('syncToR2', () => {
   });
 
   describe('sanity checks', () => {
-    it('returns error when source is missing clawdbot.json', async () => {
+    it('returns error when source is missing config file', async () => {
       const { sandbox, startProcessMock } = createMockSandbox();
       startProcessMock
         .mockResolvedValueOnce(createMockProcess('s3fs on /data/moltbot type fuse.s3fs\n'))
         .mockResolvedValueOnce(createMockProcess('')); // No "ok" output
-      
+
       const env = createMockEnvWithR2();
 
       const result = await syncToR2(sandbox, env);
 
-      // Error message still references clawdbot.json since that's the actual file name
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Sync aborted: source missing clawdbot.json');
+      expect(result.error).toBe('Sync aborted: source missing config file');
       expect(result.details).toContain('missing critical files');
     });
   });
@@ -108,12 +107,12 @@ describe('syncToR2', () => {
 
       await syncToR2(sandbox, env);
 
-      // Third call should be rsync (paths still use clawdbot internally)
+      // Third call should be rsync (uses canonical ~/.openclaw path)
       const rsyncCall = startProcessMock.mock.calls[2][0];
       expect(rsyncCall).toContain('rsync');
       expect(rsyncCall).toContain('--no-times');
       expect(rsyncCall).toContain('--delete');
-      expect(rsyncCall).toContain('/root/.clawdbot/');
+      expect(rsyncCall).toContain('/root/.openclaw/');
       expect(rsyncCall).toContain('/data/moltbot/');
     });
   });

--- a/src/routes/debug.ts
+++ b/src/routes/debug.ts
@@ -13,8 +13,8 @@ const debug = new Hono<AppEnv>();
 debug.get('/version', async (c) => {
   const sandbox = c.get('sandbox');
   try {
-    // Get moltbot version (CLI is still named clawdbot until upstream renames)
-    const versionProcess = await sandbox.startProcess('clawdbot --version');
+    // Get OpenClaw version
+    const versionProcess = await sandbox.startProcess('openclaw --version');
     await new Promise(resolve => setTimeout(resolve, 500));
     const versionLogs = await versionProcess.getLogs();
     const moltbotVersion = (versionLogs.stdout || versionLogs.stderr || '').trim();


### PR DESCRIPTION
## Summary
- Upgrades agent runtime from `clawdbot@2026.1.24-3` to `openclaw@2026.2.12` (20 days behind)
- Completes the upstream CLI rename: `clawdbot` → `openclaw`
- Migrates config paths: `~/.clawdbot/clawdbot.json` → `~/.openclaw/openclaw.json`
- Updates R2 backup structure: `clawdbot/` → `openclaw/`

## Why this matters — upstream security fixes included
| Version | Key Security Fixes |
|---|---|
| **v2026.2.12** | SSRF deny policy + hostname allowlists, webhook auth bypass fix, session key override rejection, constant-time token comparison, browser content treated as untrusted, skill sync confined to `skills/` root |
| **v2026.2.9** | Cron scheduling reliability, HTTP 400 auto-failover |
| **v2026.2.6** | Credential redaction in gateway responses, new model support (Opus 4.6, gpt-5.3-codex) |

## Files changed (11)
| File | What changed |
|---|---|
| `Dockerfile` | `clawdbot@2026.1.24-3` → `openclaw@2026.2.12`, updated paths |
| `start-moltbot.sh` | CLI commands, config paths, backward-compat R2 restore |
| `src/gateway/sync.ts` | Container + R2 paths updated, config check handles both names |
| `src/gateway/process.ts` | Detects both `openclaw` and `clawdbot` process names |
| `src/routes/api.ts` | CLI commands updated to `openclaw` |
| `src/routes/debug.ts` | Version check uses `openclaw --version` |
| `src/gateway/process.test.ts` | Test fixtures use new CLI name |
| `src/gateway/sync.test.ts` | Updated error messages and path assertions |
| `AGENTS.md` | Full documentation update |
| `skills/cloudflare-browser/SKILL.md` | Config file reference updated |
| `package-lock.json` | Lockfile regenerated |

## Backward compatibility
- `process.ts` matches both `openclaw gateway` and `clawdbot gateway` (legacy)
- `start-moltbot.sh` checks for R2 backups in both `openclaw/` and `clawdbot/` paths
- `openclaw` package auto-creates `~/.clawdbot` → `~/.openclaw` symlink

## ⚠️ Breaking change from upstream
`POST /hooks/agent` now rejects `sessionKey` overrides in payloads by default. If hooks with custom session keys are in use, set `hooks.allowRequestSessionKey: true` in config.

## Test plan
- [x] All 83 tests passing (7 test files)
- [ ] Deploy and verify gateway starts with `openclaw --version`
- [ ] Verify R2 sync works with new `openclaw/` backup path
- [ ] Verify existing sessions restored from R2 (backward compat)
- [ ] Verify device pairing works via admin UI
- [ ] Check OpenClaw dashboard shows connected status

🤖 Generated with [Claude Code](https://claude.com/claude-code)